### PR TITLE
fix: 검색 바의 예상치 못한 검색어 저장 문제 해결

### DIFF
--- a/src/api/searchApi/recentSearch.ts
+++ b/src/api/searchApi/recentSearch.ts
@@ -10,8 +10,6 @@ import {
 } from "firebase/firestore";
 import { db } from "@/firebase";
 
-import {} from "firebase/firestore";
-
 /**
  * @description Firestore에 검색 기록 저장
  */

--- a/src/lib/common/SearchBar.tsx
+++ b/src/lib/common/SearchBar.tsx
@@ -28,7 +28,7 @@ type Category = {
 
 const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
   ({ error, className, ...props }, ref) => {
-    const [value, setValue] = useState("");
+    const [value, setValue] = useState<string>("");
     const [searchResults, setSearchResults] = useState<SearchResults>([]);
     const navigate = useNavigate();
 
@@ -80,7 +80,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
     }, [value]);
 
     const handleResultClick = async (
-      query: string,
+      selectedQuery: string,
       categoryId: string,
       itemId: string
     ) => {
@@ -89,7 +89,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
       const userId = localStorage.getItem("userData");
       if (userId) {
         const { uid } = JSON.parse(userId);
-        await postSearchHistory(uid, query, categoryId, itemId);
+        await postSearchHistory(uid, selectedQuery, categoryId, itemId);
       }
     };
 
@@ -133,7 +133,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                 key={result.id}
                 className="p-2 cursor-pointer hover:bg-gray-200"
                 onClick={() =>
-                  handleResultClick(value, result.categoryId, result.id)
+                  handleResultClick(result.name, result.categoryId, result.id)
                 }
               >
                 {result.name}


### PR DESCRIPTION
## This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### #12 

## Description

- 이 이슈를 해결하려면 사용자가 검색 결과를 클릭할 때만 postSearchHistory 함수가 호출되도록 로직을 수정했습니다. 현재 코드에서는 handleResultClick 함수가 검색어 입력 값인 value를 그대로 전달하고 있어, 부분 검색어도 기록되는 문제가 발생하고 있습니다.
  - 이를 해결하기 위해 검색 결과를 클릭했을 때 handleResultClick을 호출되면서 입력한 결괏값(value)이 아닌 분리수거 제품의 이름(result.name)을 전달하도록 수정했습니다.
  -  클릭한 결과 분리수거 제품의 이름을 전달 postSearchHistory API에 전달되도록 수정했습니다.
- 밑에 자세한 코드 리뷰 남겨두었습니다.

### Screen(selected)
![image](https://github.com/user-attachments/assets/b5333006-b0d2-45a5-bdac-bb4b89e2cff5)
