### PR TITLE
refactor: 마이 지식인 페이지 게시글을 작성했던 데이터를 보여지도록 기능 구현했습니다.

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -16,7 +16,7 @@ const buttonVariants = cva(
           "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
         secondary: "bg-pink text-black hover:bg-pinkLight",
         ghost:
-          "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+          " hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
         link: "text-purple underline-offset-4 hover:underline dark:text-slate-50",
       },
       size: {

--- a/src/pages/MyQuestion.tsx
+++ b/src/pages/MyQuestion.tsx
@@ -7,11 +7,13 @@ import {
   deleteDoc,
   doc,
   Timestamp,
+  orderBy,
 } from "firebase/firestore";
 import { Link } from "react-router-dom";
 import { db } from "../firebase";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { formatDateToKoreanTime } from "@/lib/utils/dateKoreanTime";
 
 type Question = {
   id: string;
@@ -48,9 +50,11 @@ export const MyQuestion = () => {
       const fetchQuestions = async () => {
         const q = query(
           collection(db, "questions"),
-          where("authorUid", "==", currentUser.uid)
+          where("authorUid", "==", currentUser.uid),
+          orderBy("createdAt", "desc")
         );
         const querySnapshot = await getDocs(q);
+
         const questionList: Question = [];
         querySnapshot.forEach((doc) => {
           const questionData = doc.data();
@@ -61,7 +65,7 @@ export const MyQuestion = () => {
             authorUid: questionData.authorUid,
             content: questionData.content,
             createdAt: questionData.createdAt,
-            likes: questionData.likes,
+            likes: questionData.likes || 0,
             commentCount: questionData.commentCount,
           });
         });
@@ -123,12 +127,22 @@ export const MyQuestion = () => {
               className="text-black overflow-hidden whitespace-nowrap text-ellipsis inline-block w-[35vh] no-underline"
             >
               <p>{questionData.question}</p>
-              <p className="text-sm pl-1 pt-1">{questionData.content}</p>
+              <p className="text-sm mt-2">{questionData.content}</p>
+              <div className="flex items-center justify-between mt-2">
+                <div className="flex gap-2">
+                  {questionData.createdAt && (
+                    <p className="text-sm">
+                      {formatDateToKoreanTime(questionData.createdAt.toDate())}
+                    </p>
+                  )}
+                  {/* <p className="text-sm">댓글 {questionData.commentCount}개</p> */}
+                </div>
+              </div>
             </Link>
             <Button
               variant="ghost"
               size="icon"
-              className="text-black hover:text-warn-50"
+              className="text-black hover:text-purple"
               onClick={() => handleDeleteQuestion(questionData.id)}
             >
               <X width={15} height={15} />

--- a/src/pages/MyQuestion.tsx
+++ b/src/pages/MyQuestion.tsx
@@ -127,7 +127,9 @@ export const MyQuestion = () => {
               className="text-black overflow-hidden whitespace-nowrap text-ellipsis inline-block w-[35vh] no-underline"
             >
               <p>{questionData.question}</p>
-              <p className="text-sm mt-2">{questionData.content}</p>
+              <span className="text-sm text-gray-500">
+                {questionData.author}
+              </span>
               <div className="flex items-center justify-between mt-2">
                 <div className="flex gap-2">
                   {questionData.createdAt && (

--- a/src/pages/MyQuestion.tsx
+++ b/src/pages/MyQuestion.tsx
@@ -33,6 +33,7 @@ export const MyQuestion = () => {
     displayName: "",
     uid: "",
   });
+  const [likedPosts, setLikedPosts] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const userData = localStorage.getItem("userData");
@@ -43,7 +44,7 @@ export const MyQuestion = () => {
   }, []);
 
   useEffect(() => {
-    if (currentUser) {
+    if (currentUser.uid) {
       const fetchQuestions = async () => {
         const q = query(
           collection(db, "questions"),
@@ -66,6 +67,19 @@ export const MyQuestion = () => {
         });
         setQuestions(questionList);
       };
+      const fetchLikedPosts = async () => {
+        const q = query(
+          collection(db, "likes"),
+          where("userId", "==", currentUser.uid)
+        );
+        const querySnapshot = await getDocs(q);
+        const likedPostIds = new Set<string>();
+        querySnapshot.forEach((doc) => {
+          likedPostIds.add(doc.data().postId);
+        });
+        setLikedPosts(likedPostIds);
+      };
+      fetchLikedPosts();
       fetchQuestions();
     }
   }, [currentUser]);
@@ -104,6 +118,7 @@ export const MyQuestion = () => {
                 commentCount: questionData.commentCount,
                 currentUser,
                 authorUid: questionData.authorUid,
+                likedPosts: Array.from(likedPosts),
               }}
               className="text-black overflow-hidden whitespace-nowrap text-ellipsis inline-block w-[35vh] no-underline"
             >

--- a/src/pages/MyQuestion.tsx
+++ b/src/pages/MyQuestion.tsx
@@ -54,10 +54,12 @@ export const MyQuestion = () => {
           orderBy("createdAt", "desc")
         );
         const querySnapshot = await getDocs(q);
-
         const questionList: Question = [];
-        querySnapshot.forEach((doc) => {
+        for (const doc of querySnapshot.docs) {
           const questionData = doc.data();
+          const answersSnapshot = await getDocs(
+            query(collection(db, "answers"), where("questionId", "==", doc.id))
+          );
           questionList.push({
             id: doc.id,
             question: questionData.question,
@@ -66,9 +68,9 @@ export const MyQuestion = () => {
             content: questionData.content,
             createdAt: questionData.createdAt,
             likes: questionData.likes || 0,
-            commentCount: questionData.commentCount,
+            commentCount: answersSnapshot.size,
           });
-        });
+        }
         setQuestions(questionList);
       };
       const fetchLikedPosts = async () => {
@@ -137,7 +139,7 @@ export const MyQuestion = () => {
                       {formatDateToKoreanTime(questionData.createdAt.toDate())}
                     </p>
                   )}
-                  {/* <p className="text-sm">댓글 {questionData.commentCount}개</p> */}
+                  <p className="text-sm">댓글 {questionData.commentCount}개</p>
                 </div>
               </div>
             </Link>

--- a/src/pages/Qna.tsx
+++ b/src/pages/Qna.tsx
@@ -68,7 +68,7 @@ export const Qna = () => {
   }, []);
 
   useEffect(() => {
-    const getQuestions = async () => {
+    const fetchQuestions = async () => {
       const queryOrderBy = query(
         collection(db, "questions"),
         orderBy("createdAt", "desc")
@@ -94,7 +94,7 @@ export const Qna = () => {
       setQuestions(questionList);
     };
 
-    const getLiked = async () => {
+    const fetchLiked = async () => {
       if (currentUser.uid) {
         const q = query(
           collection(db, "likes"),
@@ -109,8 +109,8 @@ export const Qna = () => {
       }
     };
 
-    getQuestions();
-    getLiked();
+    fetchQuestions();
+    fetchLiked();
   }, [currentUser.uid]);
 
   const handleAddQuestion = async () => {

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -93,6 +93,10 @@ export const routes = [
 
   {
     path: "myquestion",
-    element: <MyQuestion />,
+    element: (
+      <Layout>
+        <MyQuestion />
+      </Layout>
+    ),
   },
 ];


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- 마이 지식인 페이지에  myquestion 페이지에 유저가 게시글을 작성했던 기록 데이터를 보여주고, 해당 게시글로 이동할 수 있는 라우터 기능 구현했습니다. 
- 마이 지식인 페이지에서 Answer 페이지로 이동할 때, 유저가 좋아요를 눌렀던 기록이 유지되도록 수정했습니다.
- 게시글 작성한 날짜, 작성자 이름, 댓글 수가 나타나도록 기능 구현했습니다.

### Screen(selected)
![image](https://github.com/user-attachments/assets/99f8fbe7-6b35-4319-9c26-1951082aef70)
