### PR TITLE
feat: category 페이지의 레이아웃을 재설정 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/styled-components": "^5.1.34",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.3.1",
         "firebase": "^10.14.1",
         "lucide-react": "^0.453.0",
         "react": "^18.3.1",
@@ -5182,6 +5183,31 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.49.tgz",
       "integrity": "sha512-ZXfs1Of8fDb6z7WEYZjXpgIRF6MEu8JdeGA0A40aZq6OQbS+eJpnnV49epZRna2DU/YsEjSQuGtQPPtvt6J65A==",
       "dev": true
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.1.tgz",
+      "integrity": "sha512-DutFjtEO586XptDn4cwvBJwsR/8fMa4jUk5Jk2g+/elKgu8mdn0Z2sx33g4JskvbLc1/6P8Xg4QlfELGJFcP5A=="
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.3.1.tgz",
+      "integrity": "sha512-gBY0zM+2ASvKFwRpTIOn2SLifFqOKKap9R/y0iCpJWS3bc8OHVEn2gAThGYl2uq0N+hu9aBiswffL++OYZOmDQ==",
+      "dependencies": {
+        "embla-carousel": "8.3.1",
+        "embla-carousel-reactive-utils": "8.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.3.1.tgz",
+      "integrity": "sha512-Js6rTTINNGnUGPu7l5kTcheoSbEnP5Ak2iX0G9uOoI8okTNLMzuWlEIpYFd1WP0Sq82FFcLkKM2oiO6jcElZ/Q==",
+      "peerDependencies": {
+        "embla-carousel": "8.3.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/styled-components": "^5.1.34",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.3.1",
     "firebase": "^10.14.1",
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",

--- a/src/components/WasteCategory/Category.tsx
+++ b/src/components/WasteCategory/Category.tsx
@@ -3,9 +3,9 @@ import { db } from '@/firebase';
 import { collection, getDocs } from 'firebase/firestore';
 import { NavLink } from 'react-router-dom';
 import { chunkArray } from '@/lib/utils/chunkArray';
-import { SlCarousel, SlCarouselItem } from '@shoelace-style/shoelace/dist/react';
 import { SearchBar } from '@/lib/common/SearchBar';
-import KakaoAdfit320x50 from '../KakaoAdfit320x50';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import KakaoAdfit320x100 from '../KakaoAdfit320x100';
 
 type Category = {
   id: string;
@@ -15,7 +15,7 @@ type Category = {
 
 const Category = () => {
   const [categories, setCategories] = useState<Category[]>([]);
-  const [containerWidth, setContainerWidth] = useState('w-[25rem]');
+  const [containerWidth, setContainerWidth] = useState('w-[23rem]');
 
   const chunkedCategories = chunkArray(categories, 9);
 
@@ -42,7 +42,7 @@ const Category = () => {
       if (window.innerWidth <= 395) {
         setContainerWidth('w-[21rem]');
       } else {
-        setContainerWidth('w-[25rem]');
+        setContainerWidth('w-[23rem]');
       }
     };
 
@@ -52,33 +52,35 @@ const Category = () => {
   }, []);
 
   return (
-    <>
-      <KakaoAdfit320x50 />
-      <section className="w-full h-[72vh] flex flex-col justify-center overflow-y-auto">
-        <div className="mx-auto mt-1">
-          <SearchBar />
+    <div className="flex flex-col h-full">
+      <KakaoAdfit320x100 />
+      <section className="flex-grow overflow-y-auto">
+        <div className="flex justify-center w-full mx-auto mt-2">
+          <SearchBar className="mx-auto" />
         </div>
-        <h2 className="ml-[5vh] mt-[2vh] text-xl font-bold text-purple">재활용품 분류</h2>
-        <SlCarousel mouse-dragging className="w-full h-[28rem] mx-auto">
-          {chunkedCategories.map((chunk, index) => (
-            <SlCarouselItem key={index}>
-              <div className={`grid grid-cols-3 gap-y-2 ${containerWidth}`}>
-                {chunk.map((category) => (
-                  <div key={category.id}>
-                    <NavLink to={`/category/${category.id}`} className="no-underline">
-                      <div className="bg-yellowLight w-3/4 h-[6rem] flex justify-center items-center rounded-lg mx-auto hover:bg-yellow cursor-pointer">
-                        <img src={category.imageURL} alt={category.name} className="w-[2.5rem] h-[2.5rem]" />
-                      </div>
-                      <p className="text-sm font-semibold text-center ">{category.name}</p>
-                    </NavLink>
-                  </div>
-                ))}
-              </div>
-            </SlCarouselItem>
-          ))}
-        </SlCarousel>
+        <h2 className="mt-2 ml-5 text-xl font-bold text-purple">재활용품 분류</h2>
+        <Carousel className="w-full h-full mt-4">
+          <CarouselContent>
+            {chunkedCategories.map((chunk, index) => (
+              <CarouselItem key={index}>
+                <div className={`grid grid-cols-3 gap-4 ${containerWidth} mx-auto`}>
+                  {chunk.map((category) => (
+                    <div key={category.id} className="flex flex-col items-center">
+                      <NavLink to={`/category/${category.id}`} className="no-underline">
+                        <div className="flex items-center justify-center w-24 h-24 rounded-lg cursor-pointer bg-yellowLight hover:bg-yellow">
+                          <img src={category.imageURL} alt={category.name} className="w-12 h-12" />
+                        </div>
+                        <p className="mt-2 font-semibold text-center">{category.name}</p>
+                      </NavLink>
+                    </div>
+                  ))}
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
       </section>
-    </>
+    </div>
   );
 };
 

--- a/src/components/WasteCategory/Category.tsx
+++ b/src/components/WasteCategory/Category.tsx
@@ -4,7 +4,7 @@ import { collection, getDocs } from 'firebase/firestore';
 import { NavLink } from 'react-router-dom';
 import { chunkArray } from '@/lib/utils/chunkArray';
 import { SearchBar } from '@/lib/common/SearchBar';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel';
 import KakaoAdfit320x100 from '../KakaoAdfit320x100';
 
 type Category = {

--- a/src/components/WasteCategory/CategoryDetailItems.tsx
+++ b/src/components/WasteCategory/CategoryDetailItems.tsx
@@ -2,6 +2,7 @@ import { db } from '@/firebase';
 import { doc, getDoc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import KakaoAdfit320x100 from '../KakaoAdfit320x100';
 import KakaoAdfit320x50 from '../KakaoAdfit320x50';
 
 type ItemsDetails = {
@@ -41,22 +42,29 @@ const CategoryDetailItems = () => {
   }, [categoryId, itemId]);
 
   return (
-    <section className="flex flex-col justify-center w-full overflow-y-auto ">
-      <KakaoAdfit320x50 />
-      <div className="h-[70vh] flex flex-col items-center">
-        <h3 className="text-xl font-bold text-purple  w-[20rem]">{itemsDetails?.name}</h3>
-        {itemsDetails?.imageURL && (
-          <div className="w-[20rem] h-[12rem] bg-purpleLight rounded-lg flex justify-center items-center my-2">
-            <img src={itemsDetails.imageURL} alt={itemsDetails.name} className="max-w-[40%] h-auto object-contain" />
+    <section className="flex flex-col h-full">
+      <div className="flex-grow pb-32 overflow-y-auto">
+        <KakaoAdfit320x100 />
+        <KakaoAdfit320x50 />
+        <div className="flex flex-col items-center px-4">
+          <h3 className="w-full mt-4 text-xl font-bold text-purple">{itemsDetails?.name}</h3>
+          {itemsDetails?.imageURL && (
+            <div className="flex items-center justify-center w-full h-48 my-4 rounded-lg bg-purpleLight">
+              <img
+                src={itemsDetails.imageURL}
+                alt={itemsDetails.name}
+                className="max-w-[60%] max-h-[80%] object-contain"
+              />
+            </div>
+          )}
+          <h3 className="w-full mt-4 text-xl font-bold text-purple">배출방법</h3>
+          <div className="w-full">
+            {itemsDetails?.recyclingInstructions.map((instruction, index) => (
+              <span key={index} className="my-2 font-semibold">
+                {instruction}
+              </span>
+            ))}
           </div>
-        )}
-        <h3 className="text-xl font-bold text-purple  w-[20rem] ">배출방법</h3>
-        <div className="w-[20rem]">
-          {itemsDetails?.recyclingInstructions.map((instruction) => (
-            <p key={itemsDetails.id} className="my-2 font-semibold">
-              {instruction}
-            </p>
-          ))}
         </div>
       </div>
     </section>

--- a/src/components/WasteCategory/CategoryItems.tsx
+++ b/src/components/WasteCategory/CategoryItems.tsx
@@ -3,8 +3,9 @@ import { NavLink, useParams } from 'react-router-dom';
 import { db } from '@/firebase';
 import { doc, getDoc } from 'firebase/firestore';
 import { chunkArray } from '@/lib/utils/chunkArray';
-import { SlCarousel, SlCarouselItem } from '@shoelace-style/shoelace/dist/react';
 import KakaoAdfit320x50 from '../KakaoAdfit320x50';
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import KakaoAdfit320x100 from '../KakaoAdfit320x100';
 
 type Category = {
   id: string;
@@ -15,6 +16,8 @@ type Category = {
 const CategoryItems = () => {
   const { categoryId } = useParams();
   const [categoryItems, setCategoryItems] = useState<Category[]>([]);
+  const [containerWidth, setContainerWidth] = useState('w-[25rem]');
+
   const getCategoryItems = async () => {
     try {
       if (!categoryId) {
@@ -38,33 +41,50 @@ const CategoryItems = () => {
 
   useEffect(() => {
     getCategoryItems();
+
+    const updateContainerWidth = () => {
+      if (window.innerWidth <= 395) {
+        setContainerWidth('w-[21rem]');
+      } else {
+        setContainerWidth('w-[25rem]');
+      }
+    };
+
+    updateContainerWidth();
+    window.addEventListener('resize', updateContainerWidth);
+    return () => window.removeEventListener('resize', updateContainerWidth);
   }, [categoryId]);
 
   return (
-    <>
-      <KakaoAdfit320x50 />
-      <section className="w-full h-[70vh] flex flex-col justify-center overflow-y-auto">
-        <h2 className="ml-[5vh] text-xl font-bold text-purple">재활용품 세부 품목</h2>
-        <SlCarousel pagination mouse-dragging className="w-[100%] h-[28rem] mx-auto">
-          {chunkedItems.map((chunk, index) => (
-            <SlCarouselItem key={index}>
-              <div className="grid w-full grid-cols-3 gap-y-2">
-                {chunk.map((item) => (
-                  <div key={item.id}>
-                    <NavLink to={`/category/${categoryId}/item/${item.id}`} className="text-gray-800 no-underline">
-                      <div className="bg-yellowLight w-3/4 h-[6rem] flex justify-center items-center rounded-lg mx-auto hover:bg-yellow cursor-pointer">
-                        {item.imageURL && <img src={item.imageURL} alt={item.name} className="w-[2.5rem] h-[2.5rem]" />}
-                      </div>
-                      <p className="text-sm font-semibold text-center">{item.name}</p>
-                    </NavLink>
-                  </div>
-                ))}
-              </div>
-            </SlCarouselItem>
-          ))}
-        </SlCarousel>
+    <div className="flex flex-col h-full">
+      <KakaoAdfit320x100 />
+      <section className="flex-grow overflow-y-auto">
+        <KakaoAdfit320x50 />
+        <h2 className="mt-2 ml-5 text-xl font-bold text-purple">재활용품 세부 품목</h2>
+        <Carousel className="w-full h-full mt-4">
+          <CarouselContent>
+            {chunkedItems.map((chunk, index) => (
+              <CarouselItem key={index}>
+                <div className={`grid grid-cols-3 gap-4 ${containerWidth} mx-auto`}>
+                  {chunk.map((item) => (
+                    <div key={item.id} className="flex flex-col items-center">
+                      <NavLink to={`/category/${categoryId}/item/${item.id}`} className="no-underline">
+                        <div className="flex items-center justify-center w-24 h-24 rounded-lg cursor-pointer bg-yellowLight hover:bg-yellow">
+                          {item.imageURL && <img src={item.imageURL} alt={item.name} className="w-12 h-12" />}
+                        </div>
+                        <p className="mt-2 font-semibold text-center text-gray-800">{item.name}</p>
+                      </NavLink>
+                    </div>
+                  ))}
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
       </section>
-    </>
+    </div>
   );
 };
 

--- a/src/components/WasteCategory/CategoryItems.tsx
+++ b/src/components/WasteCategory/CategoryItems.tsx
@@ -4,7 +4,7 @@ import { db } from '@/firebase';
 import { doc, getDoc } from 'firebase/firestore';
 import { chunkArray } from '@/lib/utils/chunkArray';
 import KakaoAdfit320x50 from '../KakaoAdfit320x50';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel';
 import KakaoAdfit320x100 from '../KakaoAdfit320x100';
 
 type Category = {
@@ -80,8 +80,6 @@ const CategoryItems = () => {
               </CarouselItem>
             ))}
           </CarouselContent>
-          <CarouselPrevious />
-          <CarouselNext />
         </Carousel>
       </section>
     </div>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,260 @@
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- 카테고리 페이지들을 vh단위로 높이를 임의로 설정하고 있었는데 이것은 h-full로 수정하였습니다.

### Screen(selected)
