### PR TITLE
refactor: 공지사항 높이 레이아웃 모바일 해상도에 고려하게 수정

### DIFF
--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -45,6 +45,7 @@ export const Announcement = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [isSmallScreen, setIsSmallScreen] = useState(false);
+  const [containerHeight, setContainerHeight] = useState('');
 
   useEffect(() => {
     const handleResize = () => {
@@ -55,6 +56,27 @@ export const Announcement = () => {
     window.addEventListener('resize', handleResize);
 
     return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    const updateHeight = () => {
+      if (window.innerHeight >= 1300) {
+        setContainerHeight('h-[51vh]');
+      } else if (window.innerHeight >= 1180) {
+        setContainerHeight('h-[55vh]');
+      } else if (window.innerHeight >= 1000) {
+        setContainerHeight('h-[68vh]');
+      } else if (window.innerHeight >= 940) {
+        setContainerHeight('h-[55vh]');
+      } else {
+        setContainerHeight('h-[calc(100vh-14rem)]');
+      }
+    };
+
+    updateHeight();
+    window.addEventListener('resize', updateHeight);
+
+    return () => window.removeEventListener('resize', updateHeight);
   }, []);
 
   useEffect(() => {
@@ -124,12 +146,9 @@ export const Announcement = () => {
 
   return (
     <>
-      <div className="w-full h-[2rem] bg-yellow text-purple text-center flex items-center justify-center leading-[3.75vh] text-[2vh]">
-        공지사항
-      </div>
       <KakaoAdfit320x50 />
       <div
-        className={`${isSmallScreen ? 'w-[20rem]' : 'w-[23rem]'} h-[67vh] relative overflow-y-auto overflow-x-hidden mx-auto my-[1.5vh] rounded-4`}>
+        className={`${isSmallScreen ? 'w-[20rem]' : 'w-[23rem]'} ${containerHeight}  relative overflow-y-auto overflow-x-hidden mx-auto my-[1.5vh] rounded-4`}>
         <KakaoAdfit320x100 />
         {isAdmin && (
           <div className="fixed bottom-[16vh] left-[50%] transform -translate-x-1/2">

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -44,8 +44,8 @@ export const Announcement = () => {
   });
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
-  const [isSmallScreen, setIsSmallScreen] = useState(false);
-  const [containerHeight, setContainerHeight] = useState('');
+  const [isSmallScreen, setIsSmallScreen] = useState<boolean>(false);
+  const [containerHeight, setContainerHeight] = useState<string>('');
 
   useEffect(() => {
     const handleResize = () => {
@@ -145,9 +145,9 @@ export const Announcement = () => {
   };
 
   return (
-    <>
+    <main>
       <KakaoAdfit320x50 />
-      <div
+      <section
         className={`${isSmallScreen ? 'w-[20rem]' : 'w-[23rem]'} ${containerHeight}  relative overflow-y-auto overflow-x-hidden mx-auto my-[1.5vh] rounded-4`}>
         <KakaoAdfit320x100 />
         {isAdmin && (
@@ -206,22 +206,20 @@ export const Announcement = () => {
             className=" bg-yellowLight w-full h-[6rem] mx-auto my-3 flex items-center justify-between px-3 rounded-4 text-black ">
             <NavLink to={`/announcement/${announcement.id}`} className="flex flex-col flex-grow">
               <div className="flex flex-col">
-                <span className="text-base font-semibold text-gray-900 truncate">
-                  {truncateTitle(announcement.title)}
-                </span>
-                <span className="text-sm text-gray-500">{announcement.author}</span>
+                <h2 className="text-base font-semibold text-gray-900 truncate">{truncateTitle(announcement.title)}</h2>
+                <p className="text-sm text-gray-500">{announcement.author}</p>
               </div>
               <div className="flex items-center justify-between mt-1">
                 <div className="flex gap-2">
                   {announcement.createdAt && (
-                    <p className="text-sm">{formatDateToKoreanTime(announcement.createdAt)}</p>
+                    <time className="text-sm">{formatDateToKoreanTime(announcement.createdAt)}</time>
                   )}
                 </div>
               </div>
             </NavLink>
           </div>
         ))}
-      </div>
-    </>
+      </section>
+    </main>
   );
 };

--- a/src/pages/AnnouncementDetailItem.tsx
+++ b/src/pages/AnnouncementDetailItem.tsx
@@ -102,12 +102,14 @@ export const AnnouncementDetailItem = () => {
   };
 
   return (
-    <>
+    <main>
       <KakaoAdfit320x50 />
       <section className="px-4 py-2">
         {announcement ? (
           <>
-            <p className="text-xl">{announcement.title}</p>
+            <header>
+              <h2 className="text-xl">{announcement.title}</h2>
+            </header>
             <div className="flex items-center justify-between">
               <div className="mt-2">
                 <p className="font-semibold">{announcement.author}</p>
@@ -150,10 +152,10 @@ export const AnnouncementDetailItem = () => {
               placeholder="제목"
               value={editAnnouncement.title}
               className="w-full p-2 mb-2 border"
-              onChange={(e) =>
+              onChange={(event) =>
                 setEditAnnouncement({
                   ...editAnnouncement,
-                  title: e.target.value,
+                  title: event.target.value,
                 })
               }
             />
@@ -161,10 +163,10 @@ export const AnnouncementDetailItem = () => {
               placeholder="상세 내용"
               value={editAnnouncement.details}
               className="w-full h-[10rem] "
-              onChange={(e) =>
+              onChange={(event) =>
                 setEditAnnouncement({
                   ...editAnnouncement,
-                  details: e.target.value,
+                  details: event.target.value,
                 })
               }
             />
@@ -181,6 +183,6 @@ export const AnnouncementDetailItem = () => {
           </DialogContent>
         </Dialog>
       </section>
-    </>
+    </main>
   );
 };

--- a/src/pages/Qna.tsx
+++ b/src/pages/Qna.tsx
@@ -57,8 +57,8 @@ export const Qna = () => {
   const [likedPosts, setLikedPosts] = useState<Set<string>>(new Set());
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
-  const [isSmallScreen, setIsSmallScreen] = useState(false);
-  const [containerHeight, setContainerHeight] = useState('');
+  const [isSmallScreen, setIsSmallScreen] = useState<boolean>(false);
+  const [containerHeight, setContainerHeight] = useState<string>('');
 
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- 공지사항 페이지 높이 레이아웃 모바일 해상도를 고려해서 수정했습니다.
- 공지사항, 공지사항 상세내용 페이지를 시맨틱 태그를 고려해서 추가했습니다.

### Screen(selected)
![image](https://github.com/user-attachments/assets/3a907123-293c-45e1-ae01-e7c6b6cf5f0d)
