### PR TITLE
refactor: formatContent컴포넌트로 따로 분리해서 활용하도록 수정

### DIFF
--- a/src/lib/constant/formatContent.tsx
+++ b/src/lib/constant/formatContent.tsx
@@ -1,0 +1,7 @@
+export const formatContent = (content: string) => {
+  return content.split('\n').map((line, index) => (
+    <p key={index} className="mb-2">
+      {line}
+    </p>
+  ));
+};

--- a/src/pages/AnnouncementDetailItem.tsx
+++ b/src/pages/AnnouncementDetailItem.tsx
@@ -17,6 +17,7 @@ import { formatDateToKoreanTime } from '@/lib/utils/dateKoreanTime';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { MoreHorizontal } from 'lucide-react';
 import KakaoAdfit320x50 from '@/components/KakaoAdfit320x50.tsx';
+import { formatContent } from '@/lib/constant/formatContent';
 
 export const AnnouncementDetailItem = () => {
   const { announcementId } = useParams();
@@ -135,7 +136,7 @@ export const AnnouncementDetailItem = () => {
             <p className="text-sm">{formatDateToKoreanTime(announcement.createdAt)}</p>
             <div className="mt-2">
               <hr />
-              <p className="mt-2 ">{announcement.details}</p>
+              <p className="mt-2 ">{formatContent(announcement.details)}</p>
             </div>
           </>
         ) : (

--- a/src/pages/Answer.tsx
+++ b/src/pages/Answer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dialog';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import KakaoAdfit320x50 from '@/components/KakaoAdfit320x50.tsx';
+import { formatContent } from '@/lib/constant/formatContent';
 
 type SubmittedAnswer = {
   id: string;
@@ -162,14 +163,6 @@ export const Answer = () => {
     } catch (error) {
       console.error('UPDATE 에러 발생: ', error);
     }
-  };
-
-  const formatContent = (content: string) => {
-    return content.split('\n').map((line, index) => (
-      <p key={index} className="mb-2">
-        {line}
-      </p>
-    ));
   };
 
   return (


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description
- formatContent는  문자열 콘텐츠를 줄바꿈(\n)을 기준으로 분할하여 각 줄을 `<p> `태그로 감싸는 컴포넌트입니다.
- formatContent컴포넌트로 따로 분리해서 활용하도록 수정했습니다. 


### Screen(selected)
![image](https://github.com/user-attachments/assets/afd77080-938f-4826-b697-f94f881f2048)
