### PR TITLE
refactor: routes 설정에 layout을 부모 라우트로 설정하고, 자식 라우트를 children속성으로 배치하도록 수정

### DIFF
--- a/src/components/layout/DetailLayout.tsx
+++ b/src/components/layout/DetailLayout.tsx
@@ -1,0 +1,13 @@
+import Nav from '@/components/Nav/Nav';
+import BackHeader from '@/lib/common/BackHeader';
+import { Outlet } from 'react-router-dom';
+
+export const DetailLayout = () => {
+  return (
+    <>
+      <BackHeader />
+      <Outlet />
+      <Nav />
+    </>
+  );
+};

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,11 +1,12 @@
 import Header from '@/components/Header';
 import Nav from '@/components/Nav/Nav';
+import { Outlet } from 'react-router-dom';
 
-export const Layout = ({ children }: { children: React.ReactNode }) => {
+export const MainLayout = () => {
   return (
     <>
       <Header />
-      {children}
+      <Outlet />
       <Nav />
     </>
   );

--- a/src/components/layout/NavLayout.tsx
+++ b/src/components/layout/NavLayout.tsx
@@ -1,0 +1,11 @@
+import Nav from '@/components/Nav/Nav';
+import { Outlet } from 'react-router-dom';
+
+export const NavLayout = () => {
+  return (
+    <>
+      <Outlet />
+      <Nav />
+    </>
+  );
+};

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,6 +1,6 @@
 import { DetailLayout } from '@/components/layout/DetailLayout';
 import { MainLayout } from '@/components/layout/MainLayout';
-import Nav from '@/components/Nav/Nav';
+import { NavLayout } from '@/components/layout/NavLayout';
 import CategoryDetailItems from '@/components/WasteCategory/CategoryDetailItems';
 import CategoryItems from '@/components/WasteCategory/CategoryItems';
 import {
@@ -40,31 +40,21 @@ export const routes = [
     ],
   },
   {
-    path: 'comments/:questionId',
-    element: (
-      <>
-        <Comments />
-        <Nav />
-      </>
-    ),
-  },
-  {
-    path: '/login',
-    element: (
-      <>
-        <Login />
-        <Nav />
-      </>
-    ),
-  },
-  {
-    path: '/signup',
-    element: (
-      <>
-        <SignUp />
-        <Nav />
-      </>
-    ),
+    element: <NavLayout />,
+    children: [
+      {
+        path: 'comments/:questionId',
+        element: <Comments />,
+      },
+      {
+        path: '/login',
+        element: <Login />,
+      },
+      {
+        path: '/signup',
+        element: <SignUp />,
+      },
+    ],
   },
   {
     path: '*',

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,8 +1,8 @@
+import { DetailLayout } from '@/components/layout/DetailLayout';
 import { MainLayout } from '@/components/layout/MainLayout';
 import Nav from '@/components/Nav/Nav';
 import CategoryDetailItems from '@/components/WasteCategory/CategoryDetailItems';
 import CategoryItems from '@/components/WasteCategory/CategoryItems';
-import BackHeader from '@/lib/common/BackHeader';
 import {
   Home,
   Comments,
@@ -20,7 +20,6 @@ import {
 
 export const routes = [
   {
-    path: '/',
     element: <MainLayout />,
     children: [
       { path: '/', element: <Home /> },
@@ -32,20 +31,28 @@ export const routes = [
     ],
   },
   {
-    path: '/login',
+    element: <DetailLayout />,
+    children: [
+      { path: '/pwreset', element: <PasswordReset /> },
+      { path: 'category/:categoryId/item/:itemId', element: <CategoryDetailItems /> },
+      { path: 'announcement/:announcementId', element: <AnnouncementDetailItem /> },
+      { path: 'answer/:questionId', element: <Answer /> },
+    ],
+  },
+  {
+    path: 'comments/:questionId',
     element: (
       <>
-        <Login />
+        <Comments />
         <Nav />
       </>
     ),
   },
   {
-    path: '/pwreset',
+    path: '/login',
     element: (
       <>
-        <BackHeader />
-        <PasswordReset />
+        <Login />
         <Nav />
       </>
     ),
@@ -62,44 +69,5 @@ export const routes = [
   {
     path: '*',
     element: <NotFound />,
-  },
-  {
-    path: 'category/:categoryId/item/:itemId',
-    element: (
-      <>
-        <BackHeader />
-        <CategoryDetailItems />
-        <Nav />
-      </>
-    ),
-  },
-  {
-    path: 'announcement/:announcementId',
-    element: (
-      <>
-        <BackHeader />
-        <AnnouncementDetailItem />
-        <Nav />
-      </>
-    ),
-  },
-  {
-    path: 'answer/:questionId',
-    element: (
-      <>
-        <BackHeader />
-        <Answer />
-        <Nav />
-      </>
-    ),
-  },
-  {
-    path: 'comments/:questionId',
-    element: (
-      <>
-        <Comments />
-        <Nav />
-      </>
-    ),
   },
 ];

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,4 +1,4 @@
-import { Layout } from '@/components/layout/Layout';
+import { MainLayout } from '@/components/layout/MainLayout';
 import Nav from '@/components/Nav/Nav';
 import CategoryDetailItems from '@/components/WasteCategory/CategoryDetailItems';
 import CategoryItems from '@/components/WasteCategory/CategoryItems';
@@ -21,11 +21,15 @@ import {
 export const routes = [
   {
     path: '/',
-    element: (
-      <Layout>
-        <Home />
-      </Layout>
-    ),
+    element: <MainLayout />,
+    children: [
+      { path: '/', element: <Home /> },
+      { path: 'qna', element: <Qna /> },
+      { path: 'announcement', element: <Announcement /> },
+      { path: 'mypage', element: <MyPage /> },
+      { path: 'myquestion', element: <MyQuestion /> },
+      { path: 'category/:categoryId', element: <CategoryItems /> },
+    ],
   },
   {
     path: '/login',
@@ -60,14 +64,6 @@ export const routes = [
     element: <NotFound />,
   },
   {
-    path: 'category/:categoryId',
-    element: (
-      <Layout>
-        <CategoryItems />
-      </Layout>
-    ),
-  },
-  {
     path: 'category/:categoryId/item/:itemId',
     element: (
       <>
@@ -75,22 +71,6 @@ export const routes = [
         <CategoryDetailItems />
         <Nav />
       </>
-    ),
-  },
-  {
-    path: 'qna',
-    element: (
-      <Layout>
-        <Qna />
-      </Layout>
-    ),
-  },
-  {
-    path: 'announcement',
-    element: (
-      <Layout>
-        <Announcement />
-      </Layout>
     ),
   },
   {
@@ -120,22 +100,6 @@ export const routes = [
         <Comments />
         <Nav />
       </>
-    ),
-  },
-  {
-    path: 'mypage',
-    element: (
-      <Layout>
-        <MyPage />
-      </Layout>
-    ),
-  },
-  {
-    path: 'myquestion',
-    element: (
-      <Layout>
-        <MyQuestion />
-      </Layout>
     ),
   },
 ];


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- MainLayout, NavLayout, DetailLayout 컴포넌트에 Outlet을 추가하여 자식 라우트를 렌더링할 수 있도록 수정했습니다.
- routes 설정에 layout을 부모 라우트로 설정하고, 자식 라우트를 children 속성으로 배치했습니다.

### Screen(selected)
